### PR TITLE
Use extended build to build all needed parts

### DIFF
--- a/rust-builder/src/main.rs
+++ b/rust-builder/src/main.rs
@@ -240,6 +240,8 @@ compiler-docs = true
 submodules = true
 low-priority = true
 full-bootstrap = true
+extended = true
+tools = ["cargo", "src"]
 
 [rust]
 debuginfo-level = {}


### PR DESCRIPTION
Without the extended build, compiling the hsa libraries fails because
it cannot find the rustc_driver crate.