### PR TITLE
Fix bindgen header includes

### DIFF
--- a/amd-comgr-sys/src/build.rs
+++ b/amd-comgr-sys/src/build.rs
@@ -9,7 +9,7 @@ pub fn main() {
 
   // XXX linux only
   let bindings = bindgen::Builder::default()
-    .header("/opt/rocm/include/amd_comgr.h")
+    .header("src/wrapper.h")
     .rust_target(bindgen::RustTarget::Nightly)
     .clang_arg("-I/opt/rocm/include")
     .clang_arg("-I/opt/rocm/hcc/lib/clang/9.0.0/include")

--- a/amd-comgr-sys/src/wrapper.h
+++ b/amd-comgr-sys/src/wrapper.h
@@ -1,0 +1,1 @@
+#include <amd_comgr.h>

--- a/hsa-rt-sys/src/build.rs
+++ b/hsa-rt-sys/src/build.rs
@@ -10,7 +10,7 @@ pub fn main() {
   let bindings = bindgen::Builder::default()
     .header("src/lib/wrapper.hpp")
     .rust_target(bindgen::RustTarget::Nightly)
-    .clang_arg("-I/opt/rocm/include/hsa")
+    .clang_arg("-I/opt/rocm/include")
     .clang_arg("-I/opt/rocm/hcc/lib/clang/9.0.0/include")
     .derive_debug(true)
     .derive_copy(true)

--- a/hsa-rt-sys/src/lib/wrapper.hpp
+++ b/hsa-rt-sys/src/lib/wrapper.hpp
@@ -1,11 +1,11 @@
 
-#include <hsa.h>
-#include <hsa_ext_amd.h>
-#include <hsa_ext_finalize.h>
-#include <hsa_ext_image.h>
-#include <hsa_ven_amd_aqlprofile.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#include <hsa/hsa_ext_finalize.h>
+#include <hsa/hsa_ext_image.h>
+#include <hsa/hsa_ven_amd_aqlprofile.h>
 
-#include <amd_hsa_elf.h>
-#include <amd_hsa_kernel_code.h>
-#include <amd_hsa_queue.h>
-#include <amd_hsa_signal.h>
+#include <hsa/amd_hsa_elf.h>
+#include <hsa/amd_hsa_kernel_code.h>
+#include <hsa/amd_hsa_queue.h>
+#include <hsa/amd_hsa_signal.h>


### PR DESCRIPTION
Use a wrapper header instead of a hardcoded path to find amd_comgr.h.

I also needed to add a hsa/ prefix to hsa header paths, which is how
they are defined in rocm-runtime.

I’m not sure about [rocm-runtime](https://github.com/RadeonOpenCompute/ROCR-Runtime) vs [HSA-runtime](https://github.com/HSAFoundation/HSA-Runtime-AMD) (which has the include paths without the hsa/ prefix). I guess ROCm might be the newer stack and a superset of HSA?
https://community.amd.com/t5/hsa/qestions-of-rocm-and-the-relation-between-it-and-hsa/td-p/198940

I also have one more problem when compiling kernels. It complains when adding the polly llvm arguments here, saying they are already there. Commenting them out makes it work, but I’m not sure if that’s just a problem of my system.
https://github.com/geobacter-rs/geobacter/blob/b6fccb57c19c44a445416ac8c99849ec6ef28173/runtime-core/src/codegen/worker/mod.rs#L663-L669